### PR TITLE
Add prop types package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react'
+import PropTypes from 'prop-types';
 import { Animated, View, Image, StyleSheet } from 'react-native'
 
 export default class ProgressiveImage extends Component {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "progressive",
     "react-native"
   ],
+  "dependencies": {
+    "prop-types": "^15.6.0",
+  },
   "license": "MIT",
   "author": "Dylan Vann <dylan.vann@gmail.com> (dylanvann.com)",
   "main": "index.js",


### PR DESCRIPTION
Since PropTypes has been removed completely in React 16, let's use a separate package for it. 